### PR TITLE
Spelling and "--insert v --create" fixes

### DIFF
--- a/docs/4.6/4.4-sdk-setup-15-js-tutorials-task-app.md
+++ b/docs/4.6/4.4-sdk-setup-15-js-tutorials-task-app.md
@@ -83,7 +83,7 @@ async function main () {
   console.log("************* Commands *************")
   console.log("--create <task name>");
   console.log("   Creates a task");
-  console.log("   Example: \"--insert My New Task\"");
+  console.log("   Example: \"--create My New Task\"");
   console.log("--toggle <task id>");
   console.log("   Toggles the isCompleted field");
   console.log("   Example: \"--toggle 1234abc\"");
@@ -248,7 +248,7 @@ async function main () {
   console.log("************* Commands *************")
   console.log("--create <task name>");
   console.log("   Creates a task");
-  console.log("   Example: \"--insert My New Task\"");
+  console.log("   Example: \"--create My New Task\"");
   console.log("--toggle <task id>");
   console.log("   Toggles the isComplete field");
   console.log("   Example: \"--toggle 1234abc\"");
@@ -393,7 +393,7 @@ async function main () {
   console.log("************* Commands *************")
   console.log("--create <task name>");
   console.log("   Creates a task");
-  console.log("   Example: \"--insert My New Task\"");
+  console.log("   Example: \"--create My New Task\"");
   console.log("--toggle <task id>");
   console.log("   Toggles the isComplete field");
   console.log("   Example: \"--toggle 1234abc\"");
@@ -501,7 +501,7 @@ async function main () {
   console.log("************* Commands *************")
   console.log("--create <task name>");
   console.log("   Creates a task");
-  console.log("   Example: \"--insert My New Task\"");
+  console.log("   Example: \"--create My New Task\"");
   console.log("--toggle <task id>");
   console.log("   Toggles the isComplete field");
   console.log("   Example: \"--toggle 1234abc\"");
@@ -576,7 +576,7 @@ We'll now extend our application to support editing documents. To do this we'll 
 
 1.  The ability to mark a file as deleted by setting the `isDeleted` field to `true`.
 
-2.  The ability to chage the complteted state by being able to `toggle` the `isComplete` field
+2.  The ability to change the completed state by being able to `toggle` the `isComplete` field
 
 (1)
 
@@ -633,7 +633,7 @@ async function main () {
   console.log("************* Commands *************")
   console.log("--create <task name>");
   console.log("   Creates a task");
-  console.log("   Example: \"--insert My New Task\"");
+  console.log("   Example: \"--create My New Task\"");
   console.log("--toggle <task id>");
   console.log("   Toggles the isCompleted field");
   console.log("   Example: \"--toggle 1234abc\"");
@@ -835,7 +835,7 @@ async function main () {
   console.log("************* Commands *************")
   console.log("--create <task name>");
   console.log("   Creates a task");
-  console.log("   Example: \"--insert My New Task\"");
+  console.log("   Example: \"--create My New Task\"");
   console.log("--toggle <task id>");
   console.log("   Toggles the isCompleted field");
   console.log("   Example: \"--toggle 1234abc\"");


### PR DESCRIPTION
Made minor spelling fixes.

In the create examples `--insert` was used instead of `--create`.