### PR TITLE
Prototype conditional component

### DIFF
--- a/components/conditional.tsx
+++ b/components/conditional.tsx
@@ -1,0 +1,23 @@
+import { useContext, useState, useEffect } from "react"
+import LanguageContext from "./language/context"
+
+const Conditional = ({ lang, children }) => {
+  const { language } = useContext(LanguageContext)
+  const [isLoaded, setIsLoaded] = useState(false)
+
+
+  // Copilot added this because of hydration issues
+  useEffect(() => {
+    if (language !== undefined) {
+      setIsLoaded(true)
+    }
+  }, [language])
+
+  if (!isLoaded) {
+    return null
+  }
+
+  return lang === language ? children : null
+}
+
+export default Conditional

--- a/components/language/provider.tsx
+++ b/components/language/provider.tsx
@@ -15,7 +15,7 @@ const LanguageProvider = ({ children }) => {
     router.push(
       `${router.pathname}?${currentUrlParams.toString()}`,
       undefined,
-      { shallow: false }
+      { shallow: false, scroll: false}
     )
   }
 

--- a/pages/testing_doc.mdx
+++ b/pages/testing_doc.mdx
@@ -4,6 +4,7 @@ title: Testing Doc v1
 
 import { Tabs } from "nextra/components"
 import { Topic } from "../topics"
+import Conditional from "../components/conditional"
 
 # Welcome to Ditto
 
@@ -108,3 +109,11 @@ Risus nec feugiat in fermentum posuere urna nec. A cras semper auctor neque vita
         - Rhoncus aenean vel elit scelerisque mauris pellentesque **Sed Nisi**.
 
         - In dictum non consectetur a erat nam at lectusk **Et Pharetra**.
+
+<Conditional lang="javascript">
+  ```This is for JS```
+</Conditional>
+
+<Conditional lang="java">
+  ```This is for Java```
+</Conditional>

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -31,6 +31,13 @@ const config: DocsThemeConfig = {
       </LanguageProvider>
     ),
   },
+  main({children}) {
+    return (
+      <LanguageProvider>
+        {children}
+      </LanguageProvider>
+    )
+  }
 }
 
 export default config


### PR DESCRIPTION
We're exploring how rendering the right content based on selected language might work. This is an example of conditionally rendering content _within_ an MDX file (we're also exploring conditionally rendering a specific/separate MDX file). This is a small little prototype that uses the context and selector built by @ggmanolo.